### PR TITLE
Update pom.xml dependencies to 2.0.0 stable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.openhab.binding</groupId>
     <artifactId>pom</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0</version>
   </parent>
 
   <properties>
@@ -15,42 +15,6 @@
   </properties>
   
     <repositories>
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-      <id>eclipse-snapshots</id>
-      <name>Eclipse Snapshot Repository</name>
-      <url>https://repo.eclipse.org/content/repositories/snapshots/</url>
-    </repository>
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>eclipse-releases</id>
-      <name>Eclipse Release Repository</name>
-      <url>https://repo.eclipse.org/content/repositories/releases/</url>
-    </repository>
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>jcenter</id>
-      <name>JCenter Repository</name>
-      <url>https://jcenter.bintray.com/</url>
-    </repository>
     <repository>
       <releases>
         <enabled>true</enabled>
@@ -63,54 +27,7 @@
       <name>Bintray Repository for openHAB</name>
       <url>https://dl.bintray.com/openhab/mvn/</url>
     </repository>
-    <repository>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-      <id>jfrog</id>
-      <name>JFrog OSS Repository</name>
-      <url>http://oss.jfrog.org/libs-snapshot/</url>
-    </repository>
-    <repository>
-      <releases>
-        <enabled>true</enabled>
-        <updatePolicy>never</updatePolicy>
-      </releases>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>maggu2810-bintray</id>
-      <name>Bintray Repository of maggu2810</name>
-      <url>https://dl.bintray.com/maggu2810/maven</url>
-    </repository>
-    <repository>
-      <id>p2-smarthome</id>
-      <url>http://download.eclipse.org/smarthome/updates-stable</url>
-      <layout>p2</layout>
-    </repository>
-    <repository>
-      <id>p2-openhab-core</id>
-      <url>https://dl.bintray.com/openhab/p2/openhab-core/2.0.0.x</url>
-      <layout>p2</layout>
-    </repository>
-    <repository>
-      <id>p2-openhab-deps-repo</id>
-      <url>https://dl.bintray.com/openhab/p2/openhab-deps-repo/1.0.3</url>
-      <layout>p2</layout>
-    </repository>
-    <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>central</id>
-      <name>Central Repository</name>
-      <url>https://repo.maven.apache.org/maven2</url>
-    </repository>
-  </repositories>
+   </repositories>
 
   <groupId>org.openhab.binding</groupId>
   <artifactId>org.openhab.binding.rflink</artifactId>


### PR DESCRIPTION
Now that 2.0.0 stable is out, update parent and retrieve repositories from upstream parent.